### PR TITLE
Remove swap control and adjust documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,66 @@
 # Currency Converter App
 
 ## Author
-Name: _Your Name Here_
-Student ID: _Your Student ID_
+Name: _Not provided_
+Student ID: _Not provided_
 
 ## Description
-Simple Streamlit web application that converts amounts between currencies using
-the [Frankfurter](https://www.frankfurter.app/) API. Users can retrieve the
-latest exchange rates or query historical rates for a specific date.
+Interactive Streamlit application that converts currency amounts using the
+[Frankfurter](https://www.frankfurter.app/) API. The interface lets users fetch
+the most recent exchange rate or a historical rate for a chosen date, and then
+displays a detailed breakdown of the conversion along with a two-year trend
+chart for the selected currency pair when working with the latest market rate.
+
+### Highlights
+- Fetches available currencies from Frankfurter with graceful error handling if
+  the service is unavailable.
+- Provides numeric input for the amount and dropdowns for selecting source and
+  target currencies with sensible defaults.
+- Offers buttons to convert using either the latest market rate or a
+  user-selected historical date.
+- Shows success messaging, the rounded conversion rate, converted amount, and
+  inverse rate metrics after each conversion.
+- Renders a line chart highlighting the trend over the last two years for the
+  selected currency pair after a latest-rate conversion, with labels that pair
+  month abbreviations and years for clarity.
+
+### Challenges
+- Handling API connectivity failures and ensuring the UI communicates issues to
+  the user clearly.
+- Managing Streamlit session state so that conversion results persist across
+  reruns while still clearing stale information when inputs change.
+
+### Future Enhancements
+- Support for comparing multiple target currencies simultaneously.
+- Additional visualisations such as moving averages or volatility indicators.
+- Persisting user preferences (e.g., favourite currency pairs) across sessions.
 
 ## How to Setup
-1. Ensure you have **Python 3.9+** installed.
-2. Install required packages:
+1. Ensure you have **Python 3.9+** installed (the app was built with Python
+   3.10).
+2. Install the required packages:
    ```bash
-   pip install streamlit requests
+   pip install streamlit==1.30.0 requests==2.31.0 pandas==2.2.0
    ```
 
 ## How to Run the Program
-Run the Streamlit application:
-
-```bash
-streamlit run app.py
-```
+1. Activate your Python environment (virtualenv, Conda, etc.).
+2. From the project root directory, launch the Streamlit server:
+   ```bash
+   streamlit run app.py
+   ```
+3. A browser window will open automatically. If it does not, navigate to the
+   URL printed in the terminal (typically http://localhost:8501).
+4. Enter the amount you wish to convert, pick the source and target currencies,
+   and click **Convert using latest rate** to fetch the newest rate.
+5. To look up a historical conversion, select a past date with the calendar
+   input and click **Convert using historical rate**.
+6. Review the success message, conversion metrics, and the "Rate Trend Over the
+   Last 2 Years" chart to understand how the rate has moved over time.
 
 ## Project Structure
-- `app.py` – Streamlit user interface and application logic.
+- `app.py` – Streamlit user interface and application logic, including caching
+  of rate trend data and rendering of conversion metrics and charts.
 - `api.py` – Generic HTTP helper for GET requests.
 - `frankfurter.py` – Functions interacting with the Frankfurter API.
 - `currency.py` – Helper functions for rate calculations and formatting.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,80 @@
-import streamlit as st
 import datetime
 
-from frankfurter import get_currencies_list, get_latest_rates, get_historical_rate
-from currency import reverse_rate, round_rate, format_output
+import pandas as pd
+import streamlit as st
 
+from currency import format_output, reverse_rate, round_rate
+from frankfurter import (
+    get_currencies_list,
+    get_historical_rate,
+    get_latest_rates,
+    get_rate_trend,
+)
+
+
+st.set_page_config(page_title="Currency Converter", page_icon="💱", layout="centered")
 st.title("Currency Converter")
+st.caption("Powered by the Frankfurter API")
+
+
+@st.cache_data(show_spinner=False)
+def load_rate_trend(from_currency: str, to_currency: str, years: int = 2):
+    """Cached helper to retrieve rate trend data."""
+
+    return get_rate_trend(from_currency, to_currency, years)
+
+
+def display_conversion_details(result: dict, *, show_trend: bool = False):
+    """Render the conversion summary, metrics and optional trend chart."""
+
+    if not result:
+        return
+
+    amount = result["amount"]
+    from_currency = result["from_currency"]
+    to_currency = result["to_currency"]
+    date = result["date"]
+    rate = result["rate"]
+
+    rounded_rate = round_rate(rate)
+    converted_amount = round_rate(amount * rounded_rate)
+    inverse_rate = reverse_rate(rounded_rate)
+
+    st.success(format_output(date, from_currency, to_currency, rate, amount))
+
+    metric_cols = st.columns(3)
+    metric_cols[0].metric("Rate", f"{rounded_rate}")
+    metric_cols[1].metric(
+        f"Converted Amount ({to_currency})", f"{converted_amount}"
+    )
+    metric_cols[2].metric("Inverse Rate", f"{inverse_rate}")
+
+    if show_trend:
+        trend_data = load_rate_trend(from_currency, to_currency, years=2)
+        if trend_data:
+            sorted_dates = sorted(trend_data.keys())
+            trend_df = pd.DataFrame(
+                {
+                    "Date": pd.to_datetime(sorted_dates),
+                    "Rate": [trend_data[date_key] for date_key in sorted_dates],
+                }
+            )
+            trend_df["Period"] = trend_df["Date"].dt.strftime("%b %Y")
+            trend_df = trend_df.set_index("Period")[["Rate"]]
+            st.markdown("#### Rate Trend Over the Last 2 Years")
+            st.line_chart(trend_df)
+        else:
+            st.info(
+                "Rate trend data is not available right now. Please try again later."
+            )
+
+
+def reset_results():
+    """Clear cached conversion results when inputs change."""
+
+    st.session_state.latest_result = None
+    st.session_state.historical_result = None
+
 
 # Get the list of available currencies from Frankfurter
 currencies = get_currencies_list()
@@ -13,30 +83,110 @@ currencies = get_currencies_list()
 if currencies is None:
     st.error("Unable to retrieve currency list from Frankfurter API.")
 else:
-    # Add input fields for capturing amount, from and to currencies
-    amount = st.number_input("Amount", min_value=0.0, value=1.0)
-    from_currency = st.selectbox("From", currencies, index=currencies.index("EUR") if "EUR" in currencies else 0)
-    to_currency = st.selectbox("To", currencies, index=currencies.index("USD") if "USD" in currencies else 0)
+    default_from = "EUR" if "EUR" in currencies else currencies[0]
+    other_currencies = [code for code in currencies if code != default_from]
+    default_to = "USD" if "USD" in other_currencies else (other_currencies[0] if other_currencies else default_from)
 
-    # Add a button to get and display the latest rate for selected currencies and amount
-    if st.button("Get Latest Rate"):
-        date, rate = get_latest_rates(from_currency, to_currency, amount)
-        if rate is None:
-            st.error("Unable to fetch latest conversion rate.")
+    if "from_currency" not in st.session_state:
+        st.session_state.from_currency = default_from
+    if "to_currency" not in st.session_state:
+        st.session_state.to_currency = default_to
+    if "amount_input" not in st.session_state:
+        st.session_state.amount_input = 1.0
+    if "historical_date" not in st.session_state:
+        st.session_state.historical_date = datetime.date.today()
+    if "latest_result" not in st.session_state:
+        st.session_state.latest_result = None
+    if "historical_result" not in st.session_state:
+        st.session_state.historical_result = None
+
+    st.subheader("Conversion Setup")
+    amount = st.number_input(
+        "Amount",
+        min_value=0.0,
+        key="amount_input",
+        step=0.01,
+        format="%.2f",
+        on_change=reset_results,
+    )
+
+    currency_cols = st.columns(2)
+
+    from_currency = currency_cols[0].selectbox(
+        "From",
+        currencies,
+        index=currencies.index(st.session_state.from_currency)
+        if st.session_state.from_currency in currencies
+        else 0,
+        key="from_currency",
+        on_change=reset_results,
+    )
+
+    to_currency = currency_cols[1].selectbox(
+        "To",
+        currencies,
+        index=currencies.index(st.session_state.to_currency)
+        if st.session_state.to_currency in currencies
+        else 0,
+        key="to_currency",
+        on_change=reset_results,
+    )
+
+    st.divider()
+
+    st.write("Get the most recent conversion rate available from the Frankfurter API.")
+    if st.button("Convert using latest rate", key="latest_button", use_container_width=True):
+        if amount <= 0:
+            st.warning("Please enter an amount greater than zero to convert.")
         else:
-            st.text(format_output(date, from_currency, to_currency, rate, amount))
+            with st.spinner("Fetching latest rate..."):
+                date, rate = get_latest_rates(from_currency, to_currency, amount)
+            if rate is None or date is None:
+                st.error("Unable to fetch latest conversion rate.")
+                st.session_state.latest_result = None
+            else:
+                st.session_state.latest_result = {
+                    "date": date,
+                    "rate": rate,
+                    "amount": amount,
+                    "from_currency": from_currency,
+                    "to_currency": to_currency,
+                }
 
-    # Add a date selector (calendar)
-    selected_date = st.date_input("Select Date", datetime.date.today())
+    if st.session_state.latest_result:
+        display_conversion_details(st.session_state.latest_result, show_trend=True)
 
-    # Add a button to get and display the historical rate for selected date, currencies and amount
-    if st.button("Get Historical Rate"):
-        date_str = selected_date.strftime("%Y-%m-%d")
-        rate = get_historical_rate(from_currency, to_currency, date_str, amount)
-        if rate is None:
-            st.error("Unable to fetch historical conversion rate.")
+    st.divider()
+
+    st.write("Look up the conversion rate for a specific date in the past.")
+    selected_date = st.date_input(
+        "Select Date",
+        key="historical_date",
+        max_value=datetime.date.today(),
+        on_change=reset_results,
+    )
+
+    if st.button("Convert using historical rate", key="historical_button", use_container_width=True):
+        if amount <= 0:
+            st.warning("Please enter an amount greater than zero to convert.")
         else:
-            st.text(format_output(date_str, from_currency, to_currency, rate, amount))
+            date_str = selected_date.strftime("%Y-%m-%d")
+            with st.spinner("Fetching historical rate..."):
+                rate = get_historical_rate(from_currency, to_currency, date_str, amount)
+            if rate is None:
+                st.error("Unable to fetch historical conversion rate.")
+                st.session_state.historical_result = None
+            else:
+                st.session_state.historical_result = {
+                    "date": date_str,
+                    "rate": rate,
+                    "amount": amount,
+                    "from_currency": from_currency,
+                    "to_currency": to_currency,
+                }
+
+    if st.session_state.historical_result:
+        display_conversion_details(st.session_state.historical_result)
 
 
 


### PR DESCRIPTION
## Summary
- remove the swap button from the currency selector so the interface sticks to straightforward two-column pickers
- update the README highlights to describe the streamlined selector without mentioning a swap control

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d39fabd0e8832b939221cf96acfc91